### PR TITLE
Replace pip.get_installed_distributions() with pkg_resources.working_set

### DIFF
--- a/pipconflictchecker/checker.py
+++ b/pipconflictchecker/checker.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import pip
-from pkg_resources import parse_version
+from pkg_resources import parse_version, working_set
 
 
 class Conflict(object):
@@ -205,7 +204,7 @@ class Checker(object):
         """
         Returns a dictionary of project_name => dict of projects that requires it with lists of requirements
         """
-        distributions = pip.get_installed_distributions()
+        distributions = [d for d in working_set]
         dist_requirements = {}
 
         # Compute the dist requirements and versions

--- a/pipconflictchecker/checker.py
+++ b/pipconflictchecker/checker.py
@@ -226,7 +226,7 @@ class Checker(object):
         """
         Returns a dict of project_name => version installed
         """
-        distributions = pip.get_installed_distributions()
+        distributions = [d for d in working_set]
         dist_versions = {}
 
         # Build the installed versions dict


### PR DESCRIPTION
Starting from https://pip.pypa.io/en/stable/news/#b1-2018-03-31, all the pip's APIs are moved into `pip._internal` package. Thus, we need to use `pkg_resources.working_set` as a replacement of the deperacated APIs.