### PR TITLE
Update code so it works with newer versions of pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ docs/_build/
 
 # Pycharm
 .idea
+
+# Virtualenv
+venv-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ python:
 install:
   - pip install flake8
   - virtualenv --no-site-packages venv-pip-pre-10
-  - venv-pip-pre-10/bin/pip install -q coverage flake8 virtualenv "pip==9.0.0"
+  - venv-pip-pre-10/bin/pip install -q coverage flake8 virtualenv nose mock "pip==9.0.0"
   - virtualenv --no-site-packages venv-pip-post-10
-  - venv-pip-post-10/bin/pip install -q coverage flake8 virtualenv "pip==19.3.1"
+  - venv-pip-post-10/bin/pip install -q coverage flake8 virtualenv nose mock "pip==19.3.1"
 script:
   - flake8 pipconflictchecker/
   # Test it with pip <= 10.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - '3.5'
   - '3.6'
 install:
+  - pip install flake8
   - virtualenv --no-site-packages venv-pip-pre-10
   - venv-pip-pre-10/bin/pip install -q coverage flake8 virtualenv "pip==9.0.0"
   - virtualenv --no-site-packages venv-pip-post-10

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - virtualenv --no-site-packages venv-pip-post-10
   - venv-pip-post-10/bin/pip install -q coverage flake8 virtualenv "pip==19.3.1"
 script:
-  - flake8 .
+  - flake8 pipconflictchecker/
   # Test it with pip <= 10.0.0
   - venv-pip-pre-10/bin/coverage run setup.py test
   - venv-pip-pre-10/bin/coverage report --fail-under=100

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - '3.4'
   - '3.5'
   - '3.6'
+  - '3.7'
+  - '3.8'
 install:
   - pip install flake8
   - virtualenv --no-site-packages venv-pip-pre-10

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - virtualenv --no-site-packages venv-pip-pre-10
   - venv-pip-pre-10/bin/pip install -q coverage flake8 virtualenv nose mock "pip==9.0.0"
   - virtualenv --no-site-packages venv-pip-post-10
-  - venv-pip-post-10/bin/pip install -q coverage flake8 virtualenv nose mock "pip==19.3.1"
+  - venv-pip-post-10/bin/pip install -q coverage flake8 virtualenv nose mock "pip==19.1.1"
 script:
   - flake8 pipconflictchecker/
   # Test it with pip <= 10.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,15 @@ python:
   - '3.5'
   - '3.6'
 install:
-  - pip install -q coverage flake8
+  - virtualenv --no-site-packages venv-pip-pre-10
+  - venv-pip-pre-10/bin/pip install -q coverage flake8 virtualenv "pip==9.0.0"
+  - virtualenv --no-site-packages venv-pip-post-10
+  - venv-pip-post-10/bin/pip install -q coverage flake8 virtualenv "pip==19.3.1"
 script:
   - flake8 .
-  - coverage run setup.py test
-  - coverage report --fail-under=100
+  # Test it with pip <= 10.0.0
+  - venv-pip-pre-10/bin/coverage run setup.py test
+  - venv-pip-pre-10/bin/coverage report --fail-under=100
+  # Test it with pip >= 10.0.0 (aka latest version)
+  - venv-pip-post-10/bin/coverage run setup.py test
+  - venv-pip-post-10/bin/coverage report --fail-under=100

--- a/pipconflictchecker/checker.py
+++ b/pipconflictchecker/checker.py
@@ -1,7 +1,16 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import pip
+
 from pkg_resources import parse_version
+
+try:
+    from pip import get_installed_distributions
+except ImportError:
+    # pip >= 10.0.0
+    from pkg_resources import working_set
+
+    def get_installed_distributions():
+        return working_set
 
 
 class Conflict(object):
@@ -205,7 +214,7 @@ class Checker(object):
         """
         Returns a dictionary of project_name => dict of projects that requires it with lists of requirements
         """
-        distributions = pip.get_installed_distributions()
+        distributions = get_installed_distributions()
         dist_requirements = {}
 
         # Compute the dist requirements and versions
@@ -227,7 +236,7 @@ class Checker(object):
         """
         Returns a dict of project_name => version installed
         """
-        distributions = pip.get_installed_distributions()
+        distributions = get_installed_distributions()
         dist_versions = {}
 
         # Build the installed versions dict

--- a/pipconflictchecker/checker.py
+++ b/pipconflictchecker/checker.py
@@ -4,12 +4,12 @@ from __future__ import unicode_literals
 from pkg_resources import parse_version
 
 try:
-    from pip import get_installed_distributions # pragma: no cover
-except ImportError: # pragma: no cover
+    from pip import get_installed_distributions  # pragma: no cover
+except ImportError:  # pragma: no cover
     # pip >= 10.0.0
-    from pkg_resources import working_set # pragma: no cover
+    from pkg_resources import working_set  # pragma: no cover
 
-    def get_installed_distributions(): # pragma: no cover
+    def get_installed_distributions():  # pragma: no cover
         return working_set
 
 

--- a/pipconflictchecker/checker.py
+++ b/pipconflictchecker/checker.py
@@ -4,12 +4,12 @@ from __future__ import unicode_literals
 from pkg_resources import parse_version
 
 try:
-    from pip import get_installed_distributions
-except ImportError:
+    from pip import get_installed_distributions # pragma: no cover
+except ImportError: # pragma: no cover
     # pip >= 10.0.0
-    from pkg_resources import working_set
+    from pkg_resources import working_set # pragma: no cover
 
-    def get_installed_distributions():
+    def get_installed_distributions(): # pragma: no cover
         return working_set
 
 

--- a/pipconflictchecker/tests/checker_tests.py
+++ b/pipconflictchecker/tests/checker_tests.py
@@ -328,7 +328,7 @@ class CheckerTest(TestCase):
         for dist in self.expected_distributions:
             self.assertIn(dist, distributions)
 
-    @patch('pipconflictchecker.checker.pip.get_installed_distributions')
+    @patch('pipconflictchecker.checker.get_installed_distributions')
     def test_get_requirement_versions_with_requirements(self, mock_get_installed_dists):
         # Create some fake requirements
         mock_req = Mock(Requirement)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_long_description():
 
 setup(
     name='pip-conflict-checker',
-    version='0.5.0',
+    version='0.6.0',
     description='A tool that checks installed packages against all package requirements for version conflicts.',
     long_description=get_long_description(),
     classifiers=[
@@ -25,6 +25,8 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     keywords='python pip dependencies conflicts versions checker',
     author='Ambition',


### PR DESCRIPTION
This pull request updates the code so it working with more recent versions of pip.

It's similar to change in #10, but it also working with latest version of pip where ``pip._internal.get_installed_distributions`` import is not available anymore.

I tested it locally and verified it works correctly and made sure we also run tests under more recent versions of pip on Travis.